### PR TITLE
Fixed .name of depositc checkbox

### DIFF
--- a/src/components/deposit/Deposit.vue
+++ b/src/components/deposit/Deposit.vue
@@ -80,7 +80,7 @@
                     </label>
                 </li>
                 <li v-show = "!['susd','susdv2','tbtc','ren','sbtc'].includes(currentPool)">
-                    <input id="depositc" type="checkbox" name="inf-approval" checked v-model='depositc'>
+                    <input id="depositc" type="checkbox" name="depositc" checked v-model='depositc'>
                     <label for="depositc">Deposit wrapped</label>
                 </li>
             </ul>


### PR DESCRIPTION
The "name" attribute of the Deposit Wrapped (depositc) checkbox in Deposit.vue seems to be wrong -- probably, copied from the previous, inf-approval checkbox.